### PR TITLE
READMEのロゴをSVG形式に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🖐️ TeAI Website
 
 <div align="center">
-  <img src="public/images/teai-logo.png" alt="TeAI Logo" width="200" />
+  <img src="public/images/teai-logo.svg" alt="TeAI Logo" width="200" />
   <p><strong>AI開発者のためのクラウドプラットフォーム</strong></p>
   <p>
     <a href="https://github.com/enablerdao/teai-website/blob/main/LICENSE">


### PR DESCRIPTION
READMEに表示されるロゴ画像がPNG形式では正しく表示されないため、SVG形式に変更しました。

## 変更内容
- READMEのロゴ画像参照をteai-logo.pngからteai-logo.svgに変更

## 理由
- PNG画像が正しくないファイル（テキストファイル）だったため
- SVG形式は解像度に依存せず、どのデバイスでも鮮明に表示される